### PR TITLE
그룹방 상세 조회, 결과 조회 시 menuSelectMethod 필드 값 반환 구현

### DIFF
--- a/src/main/java/babbuddy/domain/vote/presentation/dto/response/VoteRoomResultResponseDto.java
+++ b/src/main/java/babbuddy/domain/vote/presentation/dto/response/VoteRoomResultResponseDto.java
@@ -1,5 +1,6 @@
 package babbuddy.domain.vote.presentation.dto.response;
 
+import babbuddy.domain.voteroom.domain.entity.MenuSelectMethod;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,4 +12,5 @@ public class VoteRoomResultResponseDto {
     private String voteRoomId;
     private String title;
     private VoteResultDto result;
+    private MenuSelectMethod menuSelectMethod;
 }

--- a/src/main/java/babbuddy/domain/voteroom/application/service/lmpl/VoteRoomServiceImpl.java
+++ b/src/main/java/babbuddy/domain/voteroom/application/service/lmpl/VoteRoomServiceImpl.java
@@ -143,7 +143,7 @@ public class VoteRoomServiceImpl implements VoteRoomService {
 
         VoteResultDto result = calculateRankedResult(voteRoomId); // 방금 정리한 랭킹 계산 로직
 
-        return new VoteRoomResultResponseDto(room.getId(), room.getTitle(), result);
+        return new VoteRoomResultResponseDto(room.getId(), room.getTitle(), result, room.getMenuSelectMethod());
     }
 
     @Override

--- a/src/main/java/babbuddy/domain/voteroom/application/service/lmpl/VoteRoomServiceImpl.java
+++ b/src/main/java/babbuddy/domain/voteroom/application/service/lmpl/VoteRoomServiceImpl.java
@@ -127,7 +127,8 @@ public class VoteRoomServiceImpl implements VoteRoomService {
                 participantDtos,
                 participants.size(),
                 votedCount,
-                room.getUser().getId().equals(userId)
+                room.getUser().getId().equals(userId),
+                room.getMenuSelectMethod()
         );
     }
 

--- a/src/main/java/babbuddy/domain/voteroom/presentation/dto/response/VoteRoomDetailResponseDto.java
+++ b/src/main/java/babbuddy/domain/voteroom/presentation/dto/response/VoteRoomDetailResponseDto.java
@@ -1,6 +1,7 @@
 package babbuddy.domain.voteroom.presentation.dto.response;
 
 import babbuddy.domain.menu.presentation.dto.response.MenuResponseDto;
+import babbuddy.domain.voteroom.domain.entity.MenuSelectMethod;
 import babbuddy.domain.voteroom.domain.entity.VoteStatus;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -20,4 +21,5 @@ public class VoteRoomDetailResponseDto {
     private int totalParticipants;
     private int votedParticipants;
     private boolean isHostUser;
+    private MenuSelectMethod menuSelectMethod;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #34

## 📝작업 내용
그룹방 상세 조회, 그룹방 결과 조회 API 요청 시 해당 그룹방의 menuSelectMethod 필드 값이 반환되도록 구현했습니다.

<img width="268" height="118" alt="스크린샷 2025-10-17 오후 7 07 03" src="https://github.com/user-attachments/assets/b0cbd4fa-08a5-49ad-8280-155ac6d86a33" />
<img width="461" height="345" alt="스크린샷 2025-10-17 오후 7 07 11" src="https://github.com/user-attachments/assets/f60fb5fb-f377-45d8-bc37-9b5d8007c3d7" />
