### PR TITLE
일부 API 필드 반환값 추가 및 에러 수정, 그룹방 참여 및 떠나기 API 개발

### DIFF
--- a/src/main/java/babbuddy/domain/user/domain/entity/User.java
+++ b/src/main/java/babbuddy/domain/user/domain/entity/User.java
@@ -31,20 +31,23 @@ public class User {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Allergy> allergies = new ArrayList<>();
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<RecommendFood> recommendFoods = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<VoteRoom> voteRooms = new ArrayList<>();
+    
+    // 참여하고 있는 투표방 목록
+    @ManyToMany(mappedBy = "participants")
+    private List<VoteRoom> participatingVoteRooms = new ArrayList<>();
+
     @Column(nullable = false)
     private String email;
 
     // 이름
-    @Column(nullable = false)
     private String name;
 
     @Column(nullable = true)
     private String profile;
+
     // 온보딩 완료 여부 필드 추가
     @Column(nullable = false, columnDefinition = "boolean default false")
     private boolean onboardingCompleted = false;

--- a/src/main/java/babbuddy/domain/voteroom/application/service/VoteRoomService.java
+++ b/src/main/java/babbuddy/domain/voteroom/application/service/VoteRoomService.java
@@ -73,4 +73,8 @@ public interface VoteRoomService {
     void postDislikeFood(VoteRoomDislikeRequestDto req, String userId);
     List<MenuResponseDto> getDislikedFoods(String roomId); // 조회
     void deleteDislikedFood(VoteRoomDislikeRequestDto req);   // 삭제
+
+    void joinVoteRoom(String roomId, String userId);
+
+    void leaveVoteRoom(String roomId, String userId);
 }

--- a/src/main/java/babbuddy/domain/voteroom/application/service/VoteRoomService.java
+++ b/src/main/java/babbuddy/domain/voteroom/application/service/VoteRoomService.java
@@ -40,7 +40,7 @@ public interface VoteRoomService {
      *
      * @return 투표방 목록 DTO 리스트
      */
-    List<VoteRoomListResponseDto> getVoteRoomList();
+    List<VoteRoomListResponseDto> getVoteRoomList(String userId);
 
     /**
      * 투표방의 상세 정보를 조회합니다.

--- a/src/main/java/babbuddy/domain/voteroom/application/service/lmpl/VoteRoomServiceImpl.java
+++ b/src/main/java/babbuddy/domain/voteroom/application/service/lmpl/VoteRoomServiceImpl.java
@@ -245,6 +245,7 @@ public class VoteRoomServiceImpl implements VoteRoomService {
                 .orElseThrow(() -> new BabbuddyException(ErrorCode.USER_NOT_FOUND));
 
         room.addParticipant(user);
+        voteRoomRepository.save(room);
         log.info("투표방 참여 완료: roomId={}, userId={}", roomId, userId);
     }
 
@@ -257,6 +258,7 @@ public class VoteRoomServiceImpl implements VoteRoomService {
                 .orElseThrow(() -> new BabbuddyException(ErrorCode.USER_NOT_FOUND));
 
         room.removeParticipant(user);
+        voteRoomRepository.save(room);
         log.info("투표방 탈퇴 완료: roomId={}, userId={}", roomId, userId);
     }
 }

--- a/src/main/java/babbuddy/domain/voteroom/application/service/lmpl/VoteRoomServiceImpl.java
+++ b/src/main/java/babbuddy/domain/voteroom/application/service/lmpl/VoteRoomServiceImpl.java
@@ -46,11 +46,14 @@ public class VoteRoomServiceImpl implements VoteRoomService {
     public String createVoteRoom(VoteRoomRequestDto dto, String userId) {
 
         User user = userRepository.findById(userId).orElse(null);
+        List<User> participants = new ArrayList<>();
+        participants.add(user);
         VoteRoom voteRoom = VoteRoom.builder()
                 .title(dto.getTitle())
                 .votestatus(VoteStatus.ONGOING)
                 .menuSelectMethod(dto.getMenuSelectMethod())
                 .user(user)
+                .participants(participants)
                 .build();
         VoteRoom saved = voteRoomRepository.save(voteRoom);
         log.info("투표방 생성 완료: roomId={}, title={}", saved.getId(), saved.getTitle());
@@ -112,7 +115,7 @@ public class VoteRoomServiceImpl implements VoteRoomService {
         List<MenuResponseDto> menuList = menuService.getMenus(roomId);
 
         // 2. 참여자 리스트 조회
-        List<User> participants = voteRepository.findParticipantsByRoomId(roomId);
+        List<User> participants = room.getParticipants();
         List<VoteRoomUser> participantDtos = participants.stream()
                 .map(user -> new VoteRoomUser(user.getId(), user.getName(), user.getProfile()))
                 .toList();
@@ -129,7 +132,7 @@ public class VoteRoomServiceImpl implements VoteRoomService {
                 String.valueOf(room.getVotestatus()).toUpperCase(),
                 menuList,
                 participantDtos,
-                participants.size(),
+                room.getTotalParticipantCount(),
                 votedCount,
                 room.getUser().getId().equals(userId),
                 room.getMenuSelectMethod()
@@ -234,6 +237,27 @@ public class VoteRoomServiceImpl implements VoteRoomService {
         voteRoomDislikeFoodRepository.delete(dislikeFood);
     }
 
+    @Override
+    public void joinVoteRoom(String roomId, String userId) {
+        VoteRoom room = voteRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BabbuddyException(ErrorCode.ROOM_NOT_FOUND));
 
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BabbuddyException(ErrorCode.USER_NOT_FOUND));
 
+        room.addParticipant(user);
+        log.info("투표방 참여 완료: roomId={}, userId={}", roomId, userId);
+    }
+
+    @Override
+    public void leaveVoteRoom(String roomId, String userId) {
+        VoteRoom room = voteRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BabbuddyException(ErrorCode.ROOM_NOT_FOUND));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BabbuddyException(ErrorCode.USER_NOT_FOUND));
+
+        room.removeParticipant(user);
+        log.info("투표방 탈퇴 완료: roomId={}, userId={}", roomId, userId);
+    }
 }

--- a/src/main/java/babbuddy/domain/voteroom/application/service/lmpl/VoteRoomServiceImpl.java
+++ b/src/main/java/babbuddy/domain/voteroom/application/service/lmpl/VoteRoomServiceImpl.java
@@ -82,18 +82,22 @@ public class VoteRoomServiceImpl implements VoteRoomService {
     }
 
     @Override
-    public List<VoteRoomListResponseDto> getVoteRoomList() {
+    public List<VoteRoomListResponseDto> getVoteRoomList(String userId) {
         List<VoteRoom> rooms = voteRoomRepository.findAll();
+
 
         return rooms.stream()
                 .map(room -> {
                     int participantCount = voteRepository.countDistinctUsersByRoomId(room.getId());
+                    Boolean isHostUser = room.getUser().getId().equals(userId);
 
                     return new VoteRoomListResponseDto(
                             room.getId(),
                             room.getTitle(),
                             room.getVotestatus(),
-                            participantCount
+                            participantCount,
+                            isHostUser
+
                     );
                 })
                 .toList();

--- a/src/main/java/babbuddy/domain/voteroom/application/service/lmpl/VoteRoomServiceImpl.java
+++ b/src/main/java/babbuddy/domain/voteroom/application/service/lmpl/VoteRoomServiceImpl.java
@@ -91,14 +91,13 @@ public class VoteRoomServiceImpl implements VoteRoomService {
 
         return rooms.stream()
                 .map(room -> {
-                    int participantCount = voteRepository.countDistinctUsersByRoomId(room.getId());
                     Boolean isHostUser = room.getUser().getId().equals(userId);
 
                     return new VoteRoomListResponseDto(
                             room.getId(),
                             room.getTitle(),
                             room.getVotestatus(),
-                            participantCount,
+                            room.getTotalParticipantCount(),
                             isHostUser
 
                     );

--- a/src/main/java/babbuddy/domain/voteroom/domain/entity/VoteRoom.java
+++ b/src/main/java/babbuddy/domain/voteroom/domain/entity/VoteRoom.java
@@ -55,8 +55,33 @@ public class VoteRoom {
     @OneToMany(mappedBy = "voteRoom", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Menu> menus = new ArrayList<>();
 
+    // 투표방 참여자 목록 (호스트 포함)
+    @ManyToMany
+    @JoinTable(
+        name = "vote_room_participants",
+        joinColumns = @JoinColumn(name = "room_id"),
+        inverseJoinColumns = @JoinColumn(name = "user_id")
+    )
+    private List<User> participants = new ArrayList<>();
+
     public void changeStatus(VoteStatus newStatus) {
         this.votestatus = newStatus;
     }
 
+    // 참여자 추가 메서드
+    public void addParticipant(User participant) {
+        if (!this.participants.contains(participant)) {
+            this.participants.add(participant);
+        }
+    }
+
+    // 참여자 제거 메서드
+    public void removeParticipant(User participant) {
+        this.participants.remove(participant);
+    }
+
+    // 전체 참여자 수 조회 (호스트 포함)
+    public int getTotalParticipantCount() {
+        return participants.size();
+    }
 }

--- a/src/main/java/babbuddy/domain/voteroom/presentation/controller/VoteRoomController.java
+++ b/src/main/java/babbuddy/domain/voteroom/presentation/controller/VoteRoomController.java
@@ -173,4 +173,27 @@ public class VoteRoomController {
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "투표방 참여", description = "투표방에 참여하는 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "투표방 참여 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못 참여했을 경우"),
+            @ApiResponse(responseCode = "404", description = "유저 없음")
+    })
+    @PostMapping("/join/{roomId}")
+    public void joinVoteRoom(@PathVariable String roomId,
+                             @AuthenticationPrincipal String userId) {
+        voteRoomService.joinVoteRoom(roomId, userId);
+    }
+
+    @Operation(summary = "투표방 나가기", description = "투표방에서 나가는 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "투표방 나가기 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못 나갔을 경우"),
+            @ApiResponse(responseCode = "404", description = "유저 없음")
+    })
+    @PostMapping("/leave/{roomId}")
+    public void leaveVoteRoom(@PathVariable String roomId,
+                              @AuthenticationPrincipal String userId) {
+        voteRoomService.leaveVoteRoom(roomId, userId);
+    }
 }

--- a/src/main/java/babbuddy/domain/voteroom/presentation/controller/VoteRoomController.java
+++ b/src/main/java/babbuddy/domain/voteroom/presentation/controller/VoteRoomController.java
@@ -93,8 +93,8 @@ public class VoteRoomController {
             @ApiResponse(responseCode = "404", description = "유저 없음")
     })
     @GetMapping
-    public ResponseEntity<List<VoteRoomListResponseDto>> getVoteRoomList() {
-        List<VoteRoomListResponseDto> rooms = voteRoomService.getVoteRoomList();
+    public ResponseEntity<List<VoteRoomListResponseDto>> getVoteRoomList(@AuthenticationPrincipal String userId) {
+        List<VoteRoomListResponseDto> rooms = voteRoomService.getVoteRoomList(userId);
         return ResponseEntity.ok(rooms);
     }
 

--- a/src/main/java/babbuddy/domain/voteroom/presentation/dto/response/VoteRoomListResponseDto.java
+++ b/src/main/java/babbuddy/domain/voteroom/presentation/dto/response/VoteRoomListResponseDto.java
@@ -16,4 +16,5 @@ public class VoteRoomListResponseDto {
     private String title;
     private VoteStatus voteStatus;
     private int participantCount;
+    private Boolean isHostUser;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #35 #36 #40 

## 📝작업 내용

1. 그룹방 리스트 조회 시 `isHostUser` 필드를 반환하도록 개선했습니다.
2. 그룹방 상세 조회, 그룹방 리스트 조회 시 인원 카운트가 올바르게 적용되지 않는 에러를 수정했습니다. 기존 방식은 그룹방 참여 인원을 `voteRepository`를 사용해서 '투표한 인원' 으로 카운트 하고 있었는데, 이 때문에 투표하지 않으면 해당 그룹방에 매핑도, 인원 카운트도 되지 않는 이슈가 있었습니다. `User <-> VoteRoom` 간 다대다 연관관계 매핑 및 그룹방 참여자 컬럼을 `VoteRoom` 에서 별도로 관리하게 함으로서 해당 이슈를 해결했습니다.
3. 그룹방 참여 API를 개발했습니다. 올바른 `accessToken`, `roomId`를 가지고 해당 API에 요청 시 그룹방 참여가 이뤄집니다.
