### PR TITLE
투표한 메뉴 확인 필드 추가, 룰렛 선정 메뉴 저장 및 확인 API 구현, 메뉴 리스트 조회 버그 수정, ddl-auto create 변경

### DIFF
--- a/src/main/java/babbuddy/domain/menu/application/service/impl/MenuServiceImpl.java
+++ b/src/main/java/babbuddy/domain/menu/application/service/impl/MenuServiceImpl.java
@@ -88,7 +88,7 @@ public class MenuServiceImpl implements MenuService {
 
     @Override
     public List<MenuResponseDto> getMenus(String voteRoomId) {
-        List<Menu> menus = menuRepository.findAllById(voteRoomId);
+        List<Menu> menus = menuRepository.findAllByVoteRoomId(voteRoomId);
 
         return menus.stream()
                 .map(menu -> new MenuResponseDto(

--- a/src/main/java/babbuddy/domain/menu/domain/entity/Menu.java
+++ b/src/main/java/babbuddy/domain/menu/domain/entity/Menu.java
@@ -15,6 +15,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import org.springframework.lang.Nullable;
 
 @Getter
 @Entity
@@ -46,6 +47,11 @@ public class Menu {
 
     @OneToMany(mappedBy = "menu", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Vote> votes = new ArrayList<>();
+    
+    // 이 메뉴를 룰렛으로 선택한 VoteRoom (양방향 매핑)
+    @Nullable
+    @OneToOne(mappedBy = "selectedMenu")
+    private VoteRoom selectedByVoteRoom;
 
     @Builder
     public Menu(String name, VoteRoom voteRoom, User createdBy) {
@@ -56,6 +62,16 @@ public class Menu {
 
     public void changeName(String name) {
         this.name = name;
+    }
+    
+    // 이 메뉴가 룰렛으로 선택되었는지 확인
+    public boolean isSelectedByRoulette() {
+        return selectedByVoteRoom != null;
+    }
+    
+    // 이 메뉴를 룰렛으로 선택한 VoteRoom 조회
+    public VoteRoom getSelectedByVoteRoom() {
+        return selectedByVoteRoom;
     }
 
 }

--- a/src/main/java/babbuddy/domain/menu/domain/repository/MenuRepository.java
+++ b/src/main/java/babbuddy/domain/menu/domain/repository/MenuRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface MenuRepository extends JpaRepository<Menu, String> {
-    List<Menu> findAllById(String voteRoomId);
+    List<Menu> findAllByVoteRoomId(String voteRoomId);
 }

--- a/src/main/java/babbuddy/domain/vote/domain/repository/VoteRepository.java
+++ b/src/main/java/babbuddy/domain/vote/domain/repository/VoteRepository.java
@@ -24,4 +24,7 @@ public interface VoteRepository extends JpaRepository<Vote, String> {
 
     @Query("SELECT v.menu.name, COUNT(v) FROM Vote v WHERE v.voteRoom.Id = :roomId GROUP BY v.menu.name")
     List<Object[]> countVotesGroupByMenu(@Param("roomId") String roomId);
+
+    @Query("SELECT v.menu.name FROM Vote v WHERE v.user.id = :userId AND v.voteRoom.Id = :roomId")
+    String findVotedMenuNameByUserIdAndRoomId(String userId, String roomId);
 }

--- a/src/main/java/babbuddy/domain/voteroom/application/service/VoteRoomService.java
+++ b/src/main/java/babbuddy/domain/voteroom/application/service/VoteRoomService.java
@@ -2,13 +2,15 @@ package babbuddy.domain.voteroom.application.service;
 
 import babbuddy.domain.menu.presentation.dto.response.MenuResponseDto;
 import babbuddy.domain.vote.presentation.dto.response.VoteResultDto;
-import babbuddy.domain.vote.presentation.dto.response.VoteRoomResultResponseDto;
+import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomResultResponseDto;
 import babbuddy.domain.voteroom.presentation.dto.request.VoteRoomDislikeRequestDto;
 import babbuddy.domain.voteroom.presentation.dto.request.VoteRoomRequestDto;
 import babbuddy.domain.voteroom.presentation.dto.request.VoteRoomRouletteRequestDto;
 import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomDetailResponseDto;
 import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomListResponseDto;
 
+import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomRouletteDetailResponseDto;
+import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomRouletteResultResponseDto;
 import java.util.List;
 
 public interface VoteRoomService {
@@ -60,6 +62,10 @@ public interface VoteRoomService {
      * @return 최종 결과 응답 DTO
      */
     VoteRoomResultResponseDto getVoteRoomFinalResult(String voteRoomId);
+
+    VoteRoomRouletteResultResponseDto getVoteRoomRouletteFinalResult(String voteRoomId);
+
+    VoteRoomRouletteDetailResponseDto getVoteRoomRouletteDetail(String roomId, String userId);
 
     /**
      * 투표 결과 데이터를 기반으로 메뉴 랭킹을 계산합니다.

--- a/src/main/java/babbuddy/domain/voteroom/application/service/VoteRoomService.java
+++ b/src/main/java/babbuddy/domain/voteroom/application/service/VoteRoomService.java
@@ -5,6 +5,7 @@ import babbuddy.domain.vote.presentation.dto.response.VoteResultDto;
 import babbuddy.domain.vote.presentation.dto.response.VoteRoomResultResponseDto;
 import babbuddy.domain.voteroom.presentation.dto.request.VoteRoomDislikeRequestDto;
 import babbuddy.domain.voteroom.presentation.dto.request.VoteRoomRequestDto;
+import babbuddy.domain.voteroom.presentation.dto.request.VoteRoomRouletteRequestDto;
 import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomDetailResponseDto;
 import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomListResponseDto;
 
@@ -77,4 +78,6 @@ public interface VoteRoomService {
     void joinVoteRoom(String roomId, String userId);
 
     void leaveVoteRoom(String roomId, String userId);
+
+    void registerRouletteMenu(String roomId, VoteRoomRouletteRequestDto req, String userId);
 }

--- a/src/main/java/babbuddy/domain/voteroom/application/service/lmpl/VoteRoomServiceImpl.java
+++ b/src/main/java/babbuddy/domain/voteroom/application/service/lmpl/VoteRoomServiceImpl.java
@@ -122,7 +122,8 @@ public class VoteRoomServiceImpl implements VoteRoomService {
         // 3. 투표한 인원 수
         int votedCount = voteRepository.countDistinctUsersByRoomId(roomId);
 
-        // 4. 사용자들이 싫어하는거
+        // 4. 본인이 투표한 메뉴 이름
+        String votedMenuName = voteRepository.findVotedMenuNameByUserIdAndRoomId(userId, roomId);
 
 
         return new VoteRoomDetailResponseDto(
@@ -134,7 +135,8 @@ public class VoteRoomServiceImpl implements VoteRoomService {
                 room.getTotalParticipantCount(),
                 votedCount,
                 room.getUser().getId().equals(userId),
-                room.getMenuSelectMethod()
+                room.getMenuSelectMethod(),
+                votedMenuName
         );
     }
 

--- a/src/main/java/babbuddy/domain/voteroom/application/service/lmpl/VoteRoomServiceImpl.java
+++ b/src/main/java/babbuddy/domain/voteroom/application/service/lmpl/VoteRoomServiceImpl.java
@@ -1,6 +1,8 @@
 package babbuddy.domain.voteroom.application.service.lmpl;
 
 import babbuddy.domain.menu.application.service.MenuService;
+import babbuddy.domain.menu.domain.entity.Menu;
+import babbuddy.domain.menu.domain.repository.MenuRepository;
 import babbuddy.domain.menu.presentation.dto.response.MenuResponseDto;
 import babbuddy.domain.user.domain.entity.User;
 import babbuddy.domain.user.domain.repository.UserRepository;
@@ -17,6 +19,7 @@ import babbuddy.domain.voteroom.domain.repository.VoteRoomDislikeFoodRepository;
 import babbuddy.domain.voteroom.domain.repository.VoteRoomRepository;
 import babbuddy.domain.voteroom.presentation.dto.request.VoteRoomDislikeRequestDto;
 import babbuddy.domain.voteroom.presentation.dto.request.VoteRoomRequestDto;
+import babbuddy.domain.voteroom.presentation.dto.request.VoteRoomRouletteRequestDto;
 import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomDetailResponseDto;
 import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomListResponseDto;
 import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomUser;
@@ -41,6 +44,7 @@ public class VoteRoomServiceImpl implements VoteRoomService {
     private final MenuService menuService;
     private final UserRepository userRepository;
     private final VoteRoomDislikeFoodRepository voteRoomDislikeFoodRepository;
+    private final MenuRepository menuRepository;
 
     @Override
     public String createVoteRoom(VoteRoomRequestDto dto, String userId) {
@@ -262,5 +266,34 @@ public class VoteRoomServiceImpl implements VoteRoomService {
         room.removeParticipant(user);
         voteRoomRepository.save(room);
         log.info("투표방 탈퇴 완료: roomId={}, userId={}", roomId, userId);
+    }
+
+    @Override
+    public void registerRouletteMenu(String roomId, VoteRoomRouletteRequestDto req, String userId) {
+        VoteRoom room = voteRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BabbuddyException(ErrorCode.ROOM_NOT_FOUND));
+
+        if (req.getMenuSelectMethod() != room.getMenuSelectMethod()) {
+            log.error("투표방 룰렛 메뉴 등록 실패(메뉴 선택 방식 불일치): roomId={}, expectedMethod={}, actualMethod={}",
+                    roomId, room.getMenuSelectMethod(), req.getMenuSelectMethod());
+            throw new BabbuddyException(ErrorCode.MENU_SELECT_METHOD_MISMATCH);
+        }
+
+        userRepository.findById(userId)
+                .orElseThrow(() -> new BabbuddyException(ErrorCode.USER_NOT_FOUND));
+
+        if (!room.getUser().getId().equals(userId)) {
+            log.error("투표방 룰렛 메뉴 등록 실패(호스트 아님): roomId={}, userId={}", roomId, userId);
+            throw new BabbuddyException(ErrorCode.USER_NOT_HOST);
+        }
+
+        Menu menu = menuRepository.findById(req.getMenuId())
+                .orElseThrow(() -> {
+                    log.error("메뉴 조회 실패(룰렛 메뉴 등록 시도): menuId={}", req.getMenuId());
+                    return new BabbuddyException(ErrorCode.MENU_NOT_FOUND);
+                });
+
+        room.setSelectedMenu(menu);
+        log.info("투표방 룰렛 메뉴 등록 완료: roomId={}, menuName={}", roomId, menu.getName());
     }
 }

--- a/src/main/java/babbuddy/domain/voteroom/application/service/lmpl/VoteRoomServiceImpl.java
+++ b/src/main/java/babbuddy/domain/voteroom/application/service/lmpl/VoteRoomServiceImpl.java
@@ -10,7 +10,8 @@ import babbuddy.domain.vote.domain.repository.VoteRepository;
 import babbuddy.domain.vote.presentation.dto.response.MenuInfoDto;
 import babbuddy.domain.vote.presentation.dto.response.RankedMenuGroupDto;
 import babbuddy.domain.vote.presentation.dto.response.VoteResultDto;
-import babbuddy.domain.vote.presentation.dto.response.VoteRoomResultResponseDto;
+import babbuddy.domain.voteroom.domain.entity.MenuSelectMethod;
+import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomResultResponseDto;
 import babbuddy.domain.voteroom.application.service.VoteRoomService;
 import babbuddy.domain.voteroom.domain.entity.VoteRoom;
 import babbuddy.domain.voteroom.domain.entity.VoteRoomDislikeFood;
@@ -22,6 +23,8 @@ import babbuddy.domain.voteroom.presentation.dto.request.VoteRoomRequestDto;
 import babbuddy.domain.voteroom.presentation.dto.request.VoteRoomRouletteRequestDto;
 import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomDetailResponseDto;
 import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomListResponseDto;
+import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomRouletteDetailResponseDto;
+import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomRouletteResultResponseDto;
 import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomUser;
 import babbuddy.global.infra.exception.error.BabbuddyException;
 import babbuddy.global.infra.exception.error.ErrorCode;
@@ -156,6 +159,58 @@ public class VoteRoomServiceImpl implements VoteRoomService {
         VoteResultDto result = calculateRankedResult(voteRoomId); // 방금 정리한 랭킹 계산 로직
 
         return new VoteRoomResultResponseDto(room.getId(), room.getTitle(), result, room.getMenuSelectMethod());
+    }
+
+    @Override
+    public VoteRoomRouletteResultResponseDto getVoteRoomRouletteFinalResult(String voteRoomId) {
+        VoteRoom room = voteRoomRepository.findById(voteRoomId)
+                .orElseThrow(() -> new BabbuddyException(ErrorCode.ROOM_NOT_FOUND));
+
+        if (room.getMenuSelectMethod() != MenuSelectMethod.ROULETTE) {
+            throw new BabbuddyException(ErrorCode.MENU_SELECT_METHOD_MISMATCH);
+        }
+
+        String selectedMenuName = room.getSelectedMenu() != null ? room.getSelectedMenu().getName() : null;
+
+        return new VoteRoomRouletteResultResponseDto(
+                room.getId(),
+                room.getTitle(),
+                selectedMenuName,
+                room.getMenuSelectMethod()
+        );
+    }
+
+    @Override
+    public VoteRoomRouletteDetailResponseDto getVoteRoomRouletteDetail(String roomId, String userId) {
+        VoteRoom room = voteRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BabbuddyException(ErrorCode.ROOM_NOT_FOUND));
+
+        if (room.getMenuSelectMethod() != MenuSelectMethod.ROULETTE) {
+            throw new BabbuddyException(ErrorCode.MENU_SELECT_METHOD_MISMATCH);
+        }
+
+        // 1. 메뉴 리스트 조회
+        List<MenuResponseDto> menuList = menuService.getMenus(roomId);
+
+        // 2. 참여자 리스트 조회
+        List<User> participants = room.getParticipants();
+        List<VoteRoomUser> participantDtos = participants.stream()
+                .map(user -> new VoteRoomUser(user.getId(), user.getName(), user.getProfile()))
+                .toList();
+
+        boolean isHostUser = room.getUser().getId().equals(userId);
+        String selectedMenuName = room.getSelectedMenu() != null ? room.getSelectedMenu().getName() : null;
+
+        return new VoteRoomRouletteDetailResponseDto(
+                room.getId(),
+                room.getTitle(),
+                menuList,
+                participantDtos,
+                room.getTotalParticipantCount(),
+                isHostUser,
+                room.getMenuSelectMethod(),
+                selectedMenuName
+        );
     }
 
     @Override
@@ -295,5 +350,6 @@ public class VoteRoomServiceImpl implements VoteRoomService {
 
         room.setSelectedMenu(menu);
         log.info("투표방 룰렛 메뉴 등록 완료: roomId={}, menuName={}", roomId, menu.getName());
+        voteRoomRepository.save(room);
     }
 }

--- a/src/main/java/babbuddy/domain/voteroom/domain/entity/VoteRoom.java
+++ b/src/main/java/babbuddy/domain/voteroom/domain/entity/VoteRoom.java
@@ -14,6 +14,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import org.springframework.lang.Nullable;
 
 @Getter
 @Entity
@@ -54,7 +55,13 @@ public class VoteRoom {
 
     @OneToMany(mappedBy = "voteRoom", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Menu> menus = new ArrayList<>();
-
+    
+    // 룰렛으로 선택된 메뉴 (단일 메뉴)
+    @Nullable
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "selected_menu_id")
+    private Menu selectedMenu;
+    
     // 투표방 참여자 목록 (호스트 포함)
     @ManyToMany
     @JoinTable(
@@ -83,5 +90,15 @@ public class VoteRoom {
     // 전체 참여자 수 조회 (호스트 포함)
     public int getTotalParticipantCount() {
         return participants.size();
+    }
+
+    // 룰렛으로 선택된 메뉴 설정
+    public void setSelectedMenu(@Nullable Menu menu) {
+        this.selectedMenu = menu;
+    }
+    
+    // 룰렛으로 선택된 메뉴가 있는지 확인
+    public boolean hasSelectedMenu() {
+        return selectedMenu != null;
     }
 }

--- a/src/main/java/babbuddy/domain/voteroom/presentation/controller/VoteRoomController.java
+++ b/src/main/java/babbuddy/domain/voteroom/presentation/controller/VoteRoomController.java
@@ -1,13 +1,15 @@
 package babbuddy.domain.voteroom.presentation.controller;
 
 import babbuddy.domain.menu.presentation.dto.response.MenuResponseDto;
-import babbuddy.domain.vote.presentation.dto.response.VoteRoomResultResponseDto;
+import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomResultResponseDto;
 import babbuddy.domain.voteroom.application.service.VoteRoomService;
 import babbuddy.domain.voteroom.presentation.dto.request.VoteRoomDislikeRequestDto;
 import babbuddy.domain.voteroom.presentation.dto.request.VoteRoomRequestDto;
 import babbuddy.domain.voteroom.presentation.dto.request.VoteRoomRouletteRequestDto;
 import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomDetailResponseDto;
 import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomListResponseDto;
+import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomRouletteDetailResponseDto;
+import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomRouletteResultResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -209,4 +211,30 @@ public class VoteRoomController {
                                      @AuthenticationPrincipal String userId) {
         voteRoomService.registerRouletteMenu(roomId, req, userId);
     }
+
+    @Operation(summary = "룰렛 투표방 상세 조회", description = "룰렛 투표방 상세 조회 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "룰렛 투표방 상세 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못 조회했을 경우"),
+            @ApiResponse(responseCode = "404", description = "유저 없음")
+    })
+    @GetMapping("/roulette/{roomId}")
+    public VoteRoomRouletteDetailResponseDto getVoteRoomRouletteDetail(
+            @PathVariable String roomId,
+            @AuthenticationPrincipal String userId) {
+
+        return voteRoomService.getVoteRoomRouletteDetail(roomId, userId);
+    }
+
+    @Operation(summary = "룰렛 투표방 결과 조회", description = "룰렛 투표방 결과 조회 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "룰렛 투표방 결과 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못 조회했을 경우"),
+            @ApiResponse(responseCode = "404", description = "유저 없음")
+    })
+    @GetMapping("/roulette/result/{roomId}")
+    public VoteRoomRouletteResultResponseDto getVoteRoomRouletteResult(@PathVariable String roomId) {
+        return voteRoomService.getVoteRoomRouletteFinalResult(roomId);
+    }
+
 }

--- a/src/main/java/babbuddy/domain/voteroom/presentation/controller/VoteRoomController.java
+++ b/src/main/java/babbuddy/domain/voteroom/presentation/controller/VoteRoomController.java
@@ -5,6 +5,7 @@ import babbuddy.domain.vote.presentation.dto.response.VoteRoomResultResponseDto;
 import babbuddy.domain.voteroom.application.service.VoteRoomService;
 import babbuddy.domain.voteroom.presentation.dto.request.VoteRoomDislikeRequestDto;
 import babbuddy.domain.voteroom.presentation.dto.request.VoteRoomRequestDto;
+import babbuddy.domain.voteroom.presentation.dto.request.VoteRoomRouletteRequestDto;
 import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomDetailResponseDto;
 import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomListResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -195,5 +196,17 @@ public class VoteRoomController {
     public void leaveVoteRoom(@PathVariable String roomId,
                               @AuthenticationPrincipal String userId) {
         voteRoomService.leaveVoteRoom(roomId, userId);
+    }
+
+    @Operation(summary = "투표방에 룰렛으로 선정된 메뉴 등록", description = "투표방에 룰렛으로 선정된 메뉴를 등록하는 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "투표방에 룰렛 메뉴 등록 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못 등록했을 경우"),
+            @ApiResponse(responseCode = "404", description = "유저 없음")
+    })
+    @PostMapping("/roulette/{roomId}")
+    public void registerRouletteMenu(@PathVariable String roomId, @RequestBody VoteRoomRouletteRequestDto req,
+                                     @AuthenticationPrincipal String userId) {
+        voteRoomService.registerRouletteMenu(roomId, req, userId);
     }
 }

--- a/src/main/java/babbuddy/domain/voteroom/presentation/dto/request/VoteRoomRouletteRequestDto.java
+++ b/src/main/java/babbuddy/domain/voteroom/presentation/dto/request/VoteRoomRouletteRequestDto.java
@@ -1,0 +1,17 @@
+package babbuddy.domain.voteroom.presentation.dto.request;
+
+import babbuddy.domain.voteroom.domain.entity.MenuSelectMethod;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class VoteRoomRouletteRequestDto {
+
+    @NotNull(message = "메뉴 선택 방법은 필수입니다.")
+    private MenuSelectMethod menuSelectMethod;
+
+    @NotNull(message = "메뉴 아이디는 필수입니다.")
+    private String menuId;
+}

--- a/src/main/java/babbuddy/domain/voteroom/presentation/dto/response/VoteRoomDetailResponseDto.java
+++ b/src/main/java/babbuddy/domain/voteroom/presentation/dto/response/VoteRoomDetailResponseDto.java
@@ -22,4 +22,5 @@ public class VoteRoomDetailResponseDto {
     private int votedParticipants;
     private boolean isHostUser;
     private MenuSelectMethod menuSelectMethod;
+    private String votedMenuName;
 }

--- a/src/main/java/babbuddy/domain/voteroom/presentation/dto/response/VoteRoomResultResponseDto.java
+++ b/src/main/java/babbuddy/domain/voteroom/presentation/dto/response/VoteRoomResultResponseDto.java
@@ -1,5 +1,6 @@
-package babbuddy.domain.vote.presentation.dto.response;
+package babbuddy.domain.voteroom.presentation.dto.response;
 
+import babbuddy.domain.vote.presentation.dto.response.VoteResultDto;
 import babbuddy.domain.voteroom.domain.entity.MenuSelectMethod;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/babbuddy/domain/voteroom/presentation/dto/response/VoteRoomRouletteDetailResponseDto.java
+++ b/src/main/java/babbuddy/domain/voteroom/presentation/dto/response/VoteRoomRouletteDetailResponseDto.java
@@ -1,0 +1,22 @@
+package babbuddy.domain.voteroom.presentation.dto.response;
+
+import babbuddy.domain.menu.presentation.dto.response.MenuResponseDto;
+import babbuddy.domain.voteroom.domain.entity.MenuSelectMethod;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class VoteRoomRouletteDetailResponseDto {
+    private String roomId;
+    private String title;
+    private List<MenuResponseDto> menuList;
+    private List<VoteRoomUser> participantList;
+    private int totalParticipants;
+    private boolean isHostUser;
+    private MenuSelectMethod menuSelectMethod;
+    private String selectedMenuName;
+}

--- a/src/main/java/babbuddy/domain/voteroom/presentation/dto/response/VoteRoomRouletteResultResponseDto.java
+++ b/src/main/java/babbuddy/domain/voteroom/presentation/dto/response/VoteRoomRouletteResultResponseDto.java
@@ -1,0 +1,16 @@
+package babbuddy.domain.voteroom.presentation.dto.response;
+
+import babbuddy.domain.voteroom.domain.entity.MenuSelectMethod;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class VoteRoomRouletteResultResponseDto {
+    private String voteRoomId;
+    private String title;
+    private String selectedMenuName;
+    private MenuSelectMethod menuSelectMethod;
+}

--- a/src/main/java/babbuddy/global/infra/exception/error/ErrorCode.java
+++ b/src/main/java/babbuddy/global/infra/exception/error/ErrorCode.java
@@ -70,6 +70,8 @@ public enum ErrorCode {
     ROOM_NOT_CLOSED(-400, "아직 종료되지 않은 투표방입니다.",-400),
     VOTE_FORBIDDEN(-400 ,"잘못된 투표입니다" ,-400),
     FORBIDDEN_MENU_UPDATE(-400 , "잘못된 메뉴 수정입니다." , -400),
+    USER_NOT_HOST(-400 , "호스트 권한이 없습니다." , -400),
+    MENU_SELECT_METHOD_MISMATCH(-400 , "메뉴 선택 방식이 일치하지 않습니다." , -400),
 
     // openAI
     OPENAI_NOT_EXIST(-500, "내용을 생성할 수 없습니다.", 500);

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,7 +12,7 @@ spring:
     password: ${MYSQL_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
 
   servlet:
     multipart:


### PR DESCRIPTION
## #️⃣연관된 이슈

> #37 #38 

## 📝작업 내용

1. 그룹방 상세 조회 시 사용자가 투표한 메뉴를 확인하는 필드 `votedMenuName`를 추가했습니다.
2. Menu <-> VoteRoom 간에 룰렛으로 선택된 `selectedMenu` 필드와의 연관관계를 매핑했습니다.
3. 룰렛 선정 메뉴 등록, 룰렛 투표방 상세 조회, 룰렛 투표방 결과 조회 DTO 클래스를 작성했습니다.
4. 룰렛으로 선정된 메뉴 등록 API(`[POST] api/voterooms/roulette/{roomId}`) 룰렛 투표방 상세 조회 API (`[GET] /api/voterooms/roulette/{roomId}`), 룰렛 투표방 결과 조회 API(`[GET] /api/voterooms/roulette/result/{roomId}`)를 개발했습니다.
5. 기존 메뉴 리스트를 가져오는 로직에서 잘못된 리포지터리 메서드(`findAllById()`) 를 사용하고 있는 부분을 수정했습니다. (`findAllByVoteRoomId()`)
