### PR TITLE
[Hotfix] 그룹방 리스트 조회 시 응답에 menuSelectMethod 추가, menuSelectMethod 조회 API 추가

### DIFF
--- a/src/main/java/babbuddy/domain/voteroom/application/service/VoteRoomService.java
+++ b/src/main/java/babbuddy/domain/voteroom/application/service/VoteRoomService.java
@@ -2,6 +2,7 @@ package babbuddy.domain.voteroom.application.service;
 
 import babbuddy.domain.menu.presentation.dto.response.MenuResponseDto;
 import babbuddy.domain.vote.presentation.dto.response.VoteResultDto;
+import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomMenuSelectMethodResponseDto;
 import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomResultResponseDto;
 import babbuddy.domain.voteroom.presentation.dto.request.VoteRoomDislikeRequestDto;
 import babbuddy.domain.voteroom.presentation.dto.request.VoteRoomRequestDto;
@@ -86,4 +87,6 @@ public interface VoteRoomService {
     void leaveVoteRoom(String roomId, String userId);
 
     void registerRouletteMenu(String roomId, VoteRoomRouletteRequestDto req, String userId);
+
+    VoteRoomMenuSelectMethodResponseDto getMenuSelectMethod(String roomId);
 }

--- a/src/main/java/babbuddy/domain/voteroom/application/service/lmpl/VoteRoomServiceImpl.java
+++ b/src/main/java/babbuddy/domain/voteroom/application/service/lmpl/VoteRoomServiceImpl.java
@@ -11,6 +11,7 @@ import babbuddy.domain.vote.presentation.dto.response.MenuInfoDto;
 import babbuddy.domain.vote.presentation.dto.response.RankedMenuGroupDto;
 import babbuddy.domain.vote.presentation.dto.response.VoteResultDto;
 import babbuddy.domain.voteroom.domain.entity.MenuSelectMethod;
+import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomMenuSelectMethodResponseDto;
 import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomResultResponseDto;
 import babbuddy.domain.voteroom.application.service.VoteRoomService;
 import babbuddy.domain.voteroom.domain.entity.VoteRoom;
@@ -351,5 +352,13 @@ public class VoteRoomServiceImpl implements VoteRoomService {
         room.setSelectedMenu(menu);
         log.info("투표방 룰렛 메뉴 등록 완료: roomId={}, menuName={}", roomId, menu.getName());
         voteRoomRepository.save(room);
+    }
+
+    @Override
+    public VoteRoomMenuSelectMethodResponseDto getMenuSelectMethod(String roomId) {
+        VoteRoom room = voteRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BabbuddyException(ErrorCode.ROOM_NOT_FOUND));
+
+        return new VoteRoomMenuSelectMethodResponseDto(room.getMenuSelectMethod());
     }
 }

--- a/src/main/java/babbuddy/domain/voteroom/application/service/lmpl/VoteRoomServiceImpl.java
+++ b/src/main/java/babbuddy/domain/voteroom/application/service/lmpl/VoteRoomServiceImpl.java
@@ -105,8 +105,8 @@ public class VoteRoomServiceImpl implements VoteRoomService {
                             room.getTitle(),
                             room.getVotestatus(),
                             room.getTotalParticipantCount(),
-                            isHostUser
-
+                            isHostUser,
+                            room.getMenuSelectMethod()
                     );
                 })
                 .toList();

--- a/src/main/java/babbuddy/domain/voteroom/presentation/controller/VoteRoomController.java
+++ b/src/main/java/babbuddy/domain/voteroom/presentation/controller/VoteRoomController.java
@@ -1,6 +1,7 @@
 package babbuddy.domain.voteroom.presentation.controller;
 
 import babbuddy.domain.menu.presentation.dto.response.MenuResponseDto;
+import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomMenuSelectMethodResponseDto;
 import babbuddy.domain.voteroom.presentation.dto.response.VoteRoomResultResponseDto;
 import babbuddy.domain.voteroom.application.service.VoteRoomService;
 import babbuddy.domain.voteroom.presentation.dto.request.VoteRoomDislikeRequestDto;
@@ -236,5 +237,10 @@ public class VoteRoomController {
     public VoteRoomRouletteResultResponseDto getVoteRoomRouletteResult(@PathVariable String roomId) {
         return voteRoomService.getVoteRoomRouletteFinalResult(roomId);
     }
+
+    @Operation(summary = "menuSelectMethod 값 반환", description = "투표방의 menuSelectMethod 값을 반환하는 API")
+    @GetMapping("/menu-select-method/{roomId}")
+    public VoteRoomMenuSelectMethodResponseDto getMenuSelectMethod(@PathVariable String roomId) {
+        return voteRoomService.getMenuSelectMethod(roomId);}
 
 }

--- a/src/main/java/babbuddy/domain/voteroom/presentation/dto/response/VoteRoomListResponseDto.java
+++ b/src/main/java/babbuddy/domain/voteroom/presentation/dto/response/VoteRoomListResponseDto.java
@@ -1,5 +1,6 @@
 package babbuddy.domain.voteroom.presentation.dto.response;
 
+import babbuddy.domain.voteroom.domain.entity.MenuSelectMethod;
 import babbuddy.domain.voteroom.domain.entity.VoteStatus;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -17,4 +18,5 @@ public class VoteRoomListResponseDto {
     private VoteStatus voteStatus;
     private int participantCount;
     private Boolean isHostUser;
+    private MenuSelectMethod menuSelectMethod;
 }

--- a/src/main/java/babbuddy/domain/voteroom/presentation/dto/response/VoteRoomMenuSelectMethodResponseDto.java
+++ b/src/main/java/babbuddy/domain/voteroom/presentation/dto/response/VoteRoomMenuSelectMethodResponseDto.java
@@ -1,0 +1,13 @@
+package babbuddy.domain.voteroom.presentation.dto.response;
+
+import babbuddy.domain.voteroom.domain.entity.MenuSelectMethod;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class VoteRoomMenuSelectMethodResponseDto {
+    private MenuSelectMethod menuSelectMethod;
+}


### PR DESCRIPTION
1. 그룹방 리스트 조회(/api/voterooms GET) API 응답값으로 `menuSelectMethod` 필드를 반환하도록 구현했습니다.
2. `VoteRoom`의 `menuSelectMethod` 를 조회하는 API를 추가했습니다.
`/api/voterooms/menu-select-method/{roomId} GET`